### PR TITLE
Fix compatibility with Iris on 1.20+

### DIFF
--- a/src/main/java/net/ludocrypt/specialmodels/impl/bridge/IrisBridge.java
+++ b/src/main/java/net/ludocrypt/specialmodels/impl/bridge/IrisBridge.java
@@ -14,7 +14,7 @@ public class IrisBridge {
 		if (IRIS_LOADED) {
 
 			try {
-				Class<?> irisApi = Class.forName("net.coderbot.iris.apiimpl.IrisApiV0Impl");
+				Class<?> irisApi = Class.forName("net.irisshaders.iris.apiimpl.IrisApiV0Impl");
 				Field irisInstance = irisApi.getField("INSTANCE");
 				Method isShaderInUse = irisApi.getMethod("isShaderPackInUse", new Class[0]);
 				Object areThey = isShaderInUse.invoke(irisInstance.get(null), new Object[0]);


### PR DESCRIPTION
This PR (in conjunction with [this one](https://github.com/LudoCrypt/Liminal-Library/pull/8)) fixes a very minor issue with Iris shaders on 1.20+, which results in client logs ballooning in size due to exceptions, as well as shader-reliant blocks (Deep Bookshelves, Snowy Glass, etc.) rendering incorrectly when shaders are enabled.

## Current Behavior
![javaw_LwkAmCoVzY](https://github.com/user-attachments/assets/bb0ae997-b257-4302-bbe6-d572c70bb366)
![explorer_EYKnOlsYvK](https://github.com/user-attachments/assets/7539d3ce-9db4-4e2d-b2ea-496a0d4bca8b)

## Expected Behavior
![javaw_NjVGr45iY9](https://github.com/user-attachments/assets/6893012c-306d-4d2a-bae3-3e13c099f822)